### PR TITLE
Add X & Y label CSS classes from pivot table data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pivot table widget for web pages. This widget replaces the
 - Perform actions on the data in each cell.
 - React to click events on the cells.
 - Apply styling thresholds to highlight certain values
+- Apply custom styling to the X and Y labels
 - Export the table data as CSV
 - When there is no data, no table will be rendered but a (configurable) text will be shown.
 
@@ -58,8 +59,10 @@ The service should return a list of data items in the following format:
 |-------------|:-:|--|
 | idValueX    | Y | ID value for the X axis |
 | labelValueX |   | Label value for the X axis, ID value will be used if empty |
+| classValueX |   | CSS class to use for the label for the X axis, ignored if empty |
 | idValueY    | Y | ID value for the Y axis |
 | labelValueY |   | Label value for the Y axis, ID value will be used if empty |
+| classValueY |   | CSS class to use for the label for the Y axis, ignored if empty |
 | value       | ? | Value, required when Cell value action is not Count |
 
 The values can either be strings or numbers, depending on the type of data returned. As JSON does not know about dates, a date is to be transmitted as UTC date string, format: 2020-09-15T09:53:56.771Z, the widget will process it as a date.
@@ -87,8 +90,8 @@ By default cell values are centered.
 | Class                      | Description |
 |----------------------------|-
 | pivotTableTopLeft          | Topleft cell
-| pivotTableColumnHeader     | th of column header
-| pivotTableRowHeader        | th of row header
+| pivotTableColumnHeader     | th of column header. If you set the value of classValueX in your data items or set the X-axis CSS class for the datasource the value is added to the classes on the th column headers. 
+| pivotTableRowHeader        | th of row header.  If you set the value of classValueY in your data items or set the Y-axis CSS class for the datasource the value is added to the classes on the th row headers.
 | pivotTableColumnTotal      | td of the column total
 | pivotTableRowTotal         | td of the row total
 | pivotTableCell             | the td of a cell with a value

--- a/src/PivotTableWebWidget.xml
+++ b/src/PivotTableWebWidget.xml
@@ -81,6 +81,13 @@
                     <attributeType name="String"/>
                 </attributeTypes>
             </property>
+            <property key="xClassAttr" type="attribute" dataSource="ds" required="false">
+                <caption>X-axis CSS class</caption>
+                <description>The attribute for a custom CSS class that is added to the column heading.</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
             <property key="yIdAttr" type="attribute" dataSource="ds" required="false">
                 <caption>Y-axis ID</caption>
                 <description>The attribute used for grouping the data on the Y-axis.</description>
@@ -101,6 +108,13 @@
                     <attributeType name="Enum"/>
                     <attributeType name="Integer"/>
                     <attributeType name="Long"/>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="yClassAttr" type="attribute" dataSource="ds" required="false">
+                <caption>Y-axis CSS class</caption>
+                <description>The attribute for a custom CSS class that is added to the row label.</description>
+                <attributeTypes>
                     <attributeType name="String"/>
                 </attributeTypes>
             </property>

--- a/src/classes/Data.ts
+++ b/src/classes/Data.ts
@@ -147,7 +147,7 @@ export default class Data {
     }
 
     private getDataItemFromDatasource(item: ObjectItem): void {
-        const { cellValueAction, cellValueAttr, xIdAttr, xLabelAttr, yIdAttr, yLabelAttr } = this._widgetProps;
+        const { cellValueAction, cellValueAttr, xIdAttr, xLabelAttr, xClassAttr, yIdAttr, yLabelAttr, yClassAttr } = this._widgetProps;
         const { valueMap, xAxisMap, yAxisMap } = this.modelData;
 
         if (!xIdAttr || !yIdAttr) {
@@ -192,21 +192,26 @@ export default class Data {
                 aggregatedValue: 0
             });
         }
-        this.addAttrValuesToAxisMap(item, xAxisMap, xId, xLabelAttr);
-        this.addAttrValuesToAxisMap(item, yAxisMap, yId, yLabelAttr);
+        this.addAttrValuesToAxisMap(item, xAxisMap, xId, xLabelAttr, xClassAttr);
+        this.addAttrValuesToAxisMap(item, yAxisMap, yId, yLabelAttr, yClassAttr);
     }
 
-    private addAttrValuesToAxisMap(item: ObjectItem, axisMap: AxisMap, id: ModelCellValue, attr?: ListAttributeValue<Big | Date | string>): void {
+    private addAttrValuesToAxisMap(item: ObjectItem, axisMap: AxisMap, id: ModelCellValue, attr?: ListAttributeValue<Big | Date | string>, classAttr?: ListAttributeValue<string>): void {
         if (!axisMap.has(id)) {
             let labelValue: string;
+            let classValue: string = "";
             if (attr) {
                 labelValue = attr(item).displayValue;
             } else {
                 labelValue = "" + id;
             }
+            if (classAttr) {
+                classValue = " " + classAttr(item).displayValue;
+            }
             const xAxisKeyData: AxisKeyData = {
                 idValue: id,
-                labelValue
+                labelValue,
+                classValue
             };
             axisMap.set(id, xAxisKeyData);
         }
@@ -339,8 +344,8 @@ export default class Data {
                         aggregatedValue: 0
                     });
                 }
-                this.addResponseValuesToAxisMap(xAxisMap, element.idValueX, element.labelValueX);
-                this.addResponseValuesToAxisMap(yAxisMap, element.idValueY, element.labelValueY);
+                this.addResponseValuesToAxisMap(xAxisMap, element.idValueX, element.labelValueX, element.classValueX);
+                this.addResponseValuesToAxisMap(yAxisMap, element.idValueY, element.labelValueY, element.classValueY);
             }
         }
 
@@ -366,17 +371,22 @@ export default class Data {
         }
     }
 
-    private addResponseValuesToAxisMap(axisMap: AxisMap, id: ModelCellValue, responseLabelValue: string): void {
+    private addResponseValuesToAxisMap(axisMap: AxisMap, id: ModelCellValue, responseLabelValue: string, responseClassValue: string): void {
         if (!axisMap.has(id)) {
             let labelValue: string;
+            let classValue: string = "";
             if (responseLabelValue) {
                 labelValue = responseLabelValue;
             } else {
                 labelValue = "" + id;
             }
+            if (responseClassValue) {
+                classValue = " " + responseClassValue;
+            }
             const xAxisKeyData: AxisKeyData = {
                 idValue: id,
-                labelValue
+                labelValue,
+                classValue
             };
             axisMap.set(id, xAxisKeyData);
         }
@@ -625,7 +635,7 @@ export default class Data {
                 cellType: "ColumnHeader",
                 cellValue: xAxisKey.labelValue,
                 idValueX: "" + xAxisKey.idValue,
-                classes: this.CLASS_COL_HEADER
+                classes: this.CLASS_COL_HEADER + xAxisKey.classValue
             };
             return cell;
         });
@@ -694,7 +704,7 @@ export default class Data {
             cellType: "RowHeader",
             cellValue: yAxisKey.labelValue,
             idValueY: "" + yAxisKey.idValue,
-            classes: this.CLASS_ROW_HEADER
+            classes: this.CLASS_ROW_HEADER + yAxisKey.classValue
         });
 
         const row: TableRowData = { cells };

--- a/src/types/CustomTypes.ts
+++ b/src/types/CustomTypes.ts
@@ -29,6 +29,7 @@ export type ModelCellValue = string | number;
 export interface AxisKeyData {
     idValue: ModelCellValue;
     labelValue: string;
+    classValue: string;
 }
 
 export interface ModelCellData {
@@ -61,7 +62,9 @@ export interface ModelData {
 export interface InputRow {
     idValueX: string;
     labelValueX: string;
+    classValueX: string;
     idValueY: string;
     labelValueY: string;
+    classValueY: string;
     value: string | number;
 }

--- a/typings/PivotTableWebWidgetProps.d.ts
+++ b/typings/PivotTableWebWidgetProps.d.ts
@@ -57,8 +57,10 @@ export interface PivotTableWebWidgetContainerProps {
     cellValueAttr?: ListAttributeValue<BigJs.Big | Date | string>;
     xIdAttr?: ListAttributeValue<BigJs.Big | string>;
     xLabelAttr?: ListAttributeValue<BigJs.Big | string>;
+    xClassAttr?: ListAttributeValue<string>;
     yIdAttr?: ListAttributeValue<BigJs.Big | Date | string>;
     yLabelAttr?: ListAttributeValue<BigJs.Big | string>;
+    yClassAttr?: ListAttributeValue<string>;
     xIdDataType: XIdDataTypeEnum;
     yIdDataType: YIdDataTypeEnum;
     valueDataType: ValueDataTypeEnum;
@@ -105,8 +107,10 @@ export interface PivotTableWebWidgetPreviewProps {
     cellValueAttr: string;
     xIdAttr: string;
     xLabelAttr: string;
+    xClassAttr: string;
     yIdAttr: string;
     yLabelAttr: string;
+    yClassAttr: string;
     xIdDataType: XIdDataTypeEnum;
     yIdDataType: YIdDataTypeEnum;
     valueDataType: ValueDataTypeEnum;


### PR DESCRIPTION
Hi Marcel,

I have added a CSS class attribute so that you can set the CSS class in the data for individual X and Y labels. This would be helpful for example if you wanted to style all the cities from different states, or I use it to create a grouping effect so I order the rows by group and some of the Y axis labels are styled as a header for the group. I'm not sure that having the CSS classes in your tables is a good idea - I use it with the web service and generate the style classes in my OQL but I added support for both.

Sean